### PR TITLE
Initialize minimal Vite React frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Travelia is a demo monorepo project for searching flights, hotels and combined deals. It consists of a React frontend and an Express backend. The project is ready to be deployed to Vercel (backend) and GitHub Pages (frontend).
 
+## טרווליה
+
+פרויקט לדוגמה המשלב פרונטאנד מבוסס React עם Tailwind ו־Vite לצד שרת Express. הקוד מותאם לפריסה ב־Vercel וב־GitHub Pages.
+
 ## Project Structure
 
 ```

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,6 +2,10 @@
 
 React + Vite + Tailwind application for searching flights, hotels and deals.
 
+## פרונטאנד טרווליה
+
+אפליקציית דמו המבוססת על React עם Vite ו־Tailwind.
+
 ## Scripts
 
 - `npm run dev` - start development server

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,10 +1,21 @@
-"dependencies": {
-  "react": "^18.0.0",
-  "react-dom": "^18.0.0"
-},
-"devDependencies": {
-  "vite": "^4.0.0",
-  "tailwindcss": "^3.0.0",
-  "postcss": "^8.0.0",
-  "autoprefixer": "^10.0.0"
+{
+  "name": "travelia-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "vite": "^4.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "tailwindcss": "^3.3.0",
+    "postcss": "^8.4.24",
+    "autoprefixer": "^10.4.14"
+  }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,34 +1,21 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import Header from './components/Header';
-import Footer from './components/Footer';
-import Home from './pages/Home';
-import Flights from './pages/Flights';
-import Hotels from './pages/Hotels';
-import Deals from './pages/Deals';
-import Blog from './pages/Blog';
-import About from './pages/About';
-import Contact from './pages/Contact';
-import NotFound from './pages/NotFound';
-import { LanguageProvider } from './contexts/LanguageContext';
-import './index.css';
+import React from 'react';
 
+// Demo component showcasing Hebrew text and a placeholder language switch button
 export default function App() {
   return (
-    <LanguageProvider>
-      <BrowserRouter>
-        <Header />
-        <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/flights" element={<Flights />} />
-          <Route path="/hotels" element={<Hotels />} />
-          <Route path="/deals" element={<Deals />} />
-          <Route path="/blog" element={<Blog />} />
-          <Route path="/about" element={<About />} />
-          <Route path="/contact" element={<Contact />} />
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-        <Footer />
-      </BrowserRouter>
-    </LanguageProvider>
+    <div className="min-h-screen flex flex-col items-center justify-center p-4">
+      <h1 className="text-3xl font-bold mb-4 text-center">
+        ברוכים הבאים ל-Travelia
+      </h1>
+      <p className="mb-4 text-center">
+        זוהי אפליקציית דמו המבוססת על React, Vite ו-Tailwind.
+      </p>
+      <button
+        type="button"
+        className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded"
+      >
+        החלף שפה
+      </button>
+    </div>
   );
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,4 @@
+/* Tailwind base layers */
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -3,5 +3,5 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
-  base: '/',
+  base: './',
 });


### PR DESCRIPTION
## Summary
- provide Hebrew & English overview in README files
- simplify React entry files for Vite + Tailwind demo
- add build scripts and dev dependencies
- configure Vite base path for static hosting

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b056f2db48325bfc93a3a27abadbd