### PR TITLE
Enable automated GitHub Pages deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,28 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: npm install
+        working-directory: ./frontend
+      - name: Build
+        run: npm run build
+        working-directory: ./frontend
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./frontend/dist
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Travelia
 
-Travelia is a demo monorepo project for searching flights, hotels and combined deals. It consists of a React frontend and an Express backend. The project is ready to be deployed to Vercel (backend) and GitHub Pages (frontend).
+Travelia is a demo monorepo project for searching flights, hotels and combined deals. It consists of a React frontend and an Express backend. The project is configured to deploy the frontend to GitHub Pages and the backend to Vercel.
 
 ## טרווליה
 
@@ -50,4 +50,18 @@ npm run dev
 
 ## Deployment
 
-The backend is configured for Vercel using `vercel.json`. The frontend can be deployed to GitHub Pages by running `npm run build` in the `frontend` folder and pushing the contents of `frontend/dist` to the `gh-pages` branch.
+### GitHub Pages
+
+The workflow in `.github/workflows/deploy.yml` automatically builds the React
+frontend and publishes the `frontend/dist` folder to **GitHub Pages** whenever
+changes are pushed to the `main` branch. No manual steps are required.
+
+### Vercel
+
+The Express backend contains a `vercel.json` file so it can be deployed to
+Vercel. Create a Vercel project using the `backend` folder as the root and set
+the build command to `npm start`.
+
+If you wish to deploy the static frontend to Vercel instead, use the `frontend`
+folder as the project root, keep the build command as `npm run build` and set
+the output directory to `dist`.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -13,3 +13,6 @@ React + Vite + Tailwind application for searching flights, hotels and deals.
 - `npm run preview` - preview production build
 
 Assets in `src/assets` and `public` are placeholders. Replace `logo.svg`, `demo-image.jpg` and `favicon.ico` with your own files.
+
+The entry `index.html` lives in the `frontend` folder so it can be served
+correctly on GitHub Pages and Vercel.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,11 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="icon" href="/favicon.ico" />
+    <link rel="icon" href="./favicon.ico" />
     <title>Travelia</title>
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <script type="module" src="./src/main.jsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- move `index.html` to the `frontend` root and adjust paths
- add workflow to deploy the built frontend to GitHub Pages
- document deployment to GitHub Pages and Vercel

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*
- `npm install` in backend *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685b167235608325b616b61a8acee359