### PR TITLE
Add production Vite config and deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Images such as `logo.svg`, `demo-image.jpg`, and `favicon.ico` are simple placeh
 ## Environment Variables
 
 Create `.env` files in the root and backend folders based on `.env.example`. Include your Travelpayouts API key and any other secrets.
+For the frontend, you can set `VITE_BASE_URL` to control the base path used by
+Vite when building for production. This is useful when deploying to GitHub
+Pages.
 
 ## Installation
 
@@ -62,6 +65,8 @@ npm run dev
 The workflow in `.github/workflows/deploy.yml` automatically builds the React
 frontend and publishes the `frontend/dist` folder to **GitHub Pages** whenever
 changes are pushed to the `main` branch. No manual steps are required.
+Set `VITE_BASE_URL` in `frontend/.env` to `/your-repo-name/` so that asset
+paths resolve correctly when served from a subfolder.
 
 ### Vercel
 
@@ -71,7 +76,8 @@ the build command to `npm start`.
 
 If you wish to deploy the static frontend to Vercel instead, use the `frontend`
 folder as the project root, keep the build command as `npm run build` and set
-the output directory to `dist`.
+the output directory to `dist`. Ensure `VITE_BASE_URL` is `/` in `frontend/.env`
+so the site works correctly at the domain root.
 
 ## Features
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -16,3 +16,18 @@ Assets in `src/assets` and `public` are placeholders. Replace `logo.svg`, `demo-
 
 The entry `index.html` lives in the `frontend` folder so it can be served
 correctly on GitHub Pages and Vercel.
+
+## Deployment
+
+### GitHub Pages
+
+1. Create a `.env` file in this folder and set `VITE_BASE_URL` to your
+   repository name, e.g. `/travelia/`.
+2. Run `npm run build` to generate the `dist` folder.
+3. Deploy the contents of `dist` to GitHub Pages or use the provided workflow.
+
+### Vercel
+
+1. Ensure `VITE_BASE_URL` is set to `/` (or leave it unset).
+2. In Vercel, set the project root to `frontend`, the build command to
+   `npm run build`, and the output directory to `dist`.

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,7 +1,12 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 
-export default defineConfig({
-  plugins: [react()],
-  base: './',
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  return {
+    plugins: [react()],
+    // Use VITE_BASE_URL to control the base path in production.
+    // For GitHub Pages set it to "/your-repo-name/".
+    base: env.VITE_BASE_URL || '/',
+  };
 });


### PR DESCRIPTION
## Summary
- allow configuring the base path via `VITE_BASE_URL`
- document the new environment variable in the root README
- add deployment instructions for GitHub Pages and Vercel in the frontend README

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b31dfd698832581914d133c5e3c37