### PR TITLE
Enhance header and footer

### DIFF
--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -1,7 +1,16 @@
+import { useContext } from 'react';
+import { LanguageContext } from '../contexts/LanguageContext';
+
 export default function Footer() {
+  const { language } = useContext(LanguageContext);
   return (
-    <footer className="p-4 bg-gray-200 text-center text-sm">
-      &copy; {new Date().getFullYear()} Travelia
+    <footer className="bg-gray-200 text-sm">
+      <div
+        className="container mx-auto p-4 text-center"
+        dir={language === 'he' ? 'rtl' : 'ltr'}
+      >
+        &copy; {new Date().getFullYear()} Travelia
+      </div>
     </footer>
   );
 }

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,31 +1,72 @@
-import { useContext } from 'react';
+import { useContext, useState } from 'react';
 import { LanguageContext } from '../contexts/LanguageContext';
 import useTranslation from '../hooks/useTranslation';
 
 export default function Header({ onNavigate }) {
   const { language, setLanguage } = useContext(LanguageContext);
   const t = useTranslation();
+  const [menuOpen, setMenuOpen] = useState(false);
   const pages = ['home', 'flights', 'hotels', 'deals', 'blog', 'contact'];
+  const isRTL = language === 'he';
+
+  const toggleMenu = () => setMenuOpen((v) => !v);
+  const navigate = (p) => {
+    onNavigate(p);
+    setMenuOpen(false);
+  };
+
   return (
-    <header className="p-4 bg-blue-600 text-white flex flex-wrap justify-between items-center gap-4">
-      <div className="flex items-center gap-4">
-        <h1 className="text-xl font-bold">Travelia</h1>
-        <nav className="flex gap-2">
+    <header className="bg-blue-600 text-white shadow">
+      <div
+        className={`container mx-auto flex flex-wrap items-center justify-between p-4 ${isRTL ? 'md:flex-row-reverse' : ''}`}
+      >
+        <div className="flex items-center gap-2">
+          <h1 className="text-xl font-bold">Travelia</h1>
+          <button
+            className="md:hidden"
+            onClick={toggleMenu}
+            aria-label="Toggle navigation"
+          >
+            <svg
+              className="w-6 h-6"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M4 6h16M4 12h16M4 18h16"
+              />
+            </svg>
+          </button>
+        </div>
+        <nav
+          className={`${
+            menuOpen ? 'flex' : 'hidden'
+          } w-full flex-col gap-2 mt-2 md:mt-0 md:flex md:w-auto ${isRTL ? 'md:flex-row-reverse' : 'md:flex-row'} md:items-center`}
+        >
           {pages.map((p) => (
-            <button key={p} onClick={() => onNavigate(p)} className="hover:underline">
+            <button
+              key={p}
+              onClick={() => navigate(p)}
+              className="px-3 py-1 hover:underline text-left md:text-center"
+            >
               {t(p)}
             </button>
           ))}
         </nav>
+        <select
+          value={language}
+          onChange={(e) => setLanguage(e.target.value)}
+          className="text-black p-1 rounded mt-2 md:mt-0"
+          aria-label={t('language')}
+        >
+          <option value="en">EN</option>
+          <option value="he">HE</option>
+        </select>
       </div>
-      <select
-        value={language}
-        onChange={(e) => setLanguage(e.target.value)}
-        className="text-black p-1 rounded"
-      >
-        <option value="he">HE</option>
-        <option value="en">EN</option>
-      </select>
     </header>
   );
 }


### PR DESCRIPTION
## Summary
- upgrade `Header` with mobile menu, language switcher and RTL/LTR support
- make `Footer` aware of language direction

## Testing
- `npm test` (fails: Missing script)
- `npm test` in backend (prints `no tests`)

------
https://chatgpt.com/codex/tasks/task_e_685b32fd52f4832594f6effe5c32e421