### PR TITLE
Add useTranslation hook and language context file

### DIFF
--- a/frontend/src/contexts/LanguageContext.js
+++ b/frontend/src/contexts/LanguageContext.js
@@ -1,0 +1,12 @@
+import { createContext, useState } from 'react';
+
+export const LanguageContext = createContext({
+  language: 'he',
+  setLanguage: () => {},
+});
+
+export function LanguageProvider({ children }) {
+  const [language, setLanguage] = useState('he');
+  const value = { language, setLanguage };
+  return <LanguageContext.Provider value={value}>{children}</LanguageContext.Provider>;
+}

--- a/frontend/src/hooks/useTranslation.js
+++ b/frontend/src/hooks/useTranslation.js
@@ -7,5 +7,11 @@ const resources = { en, he };
 
 export default function useTranslation() {
   const { language } = useContext(LanguageContext);
-  return (key) => resources[language][key] || key;
+  const translations = resources[language] || {};
+
+  function t(key) {
+    return translations[key] || key;
+  }
+
+  return t;
 }


### PR DESCRIPTION
## Summary
- add `src/contexts/LanguageContext.js` with language provider implementation
- tweak `src/hooks/useTranslation.js` to return a named `t` function

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b462200d483258dbaf381c37242d0