### PR TITLE
Fix Vite base config for production

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,12 +1,17 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
-// הגדרת base: שם הריפו שלך ב-GitHub Pages חייב להופיע כאן.
-// לדוג' אם כתובת האתר היא https://shayfly.github.io/Travelia/ 
-// ה-base חייב להיות '/Travelia/'
+// base configuration:
+// For GitHub Pages, set VITE_BASE_URL in `.env` to your repo name,
+// e.g. `/Travelia/`. For Vercel or any root domain deployment,
+// leave it unset so the base defaults to `/`.
 
-export default defineConfig({
-  plugins: [react()],
-  base: '/Travelia/',
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  return {
+    plugins: [react()],
+    // Use VITE_BASE_URL from the environment or fall back to root ("/")
+    base: env.VITE_BASE_URL || '/',
+  };
 });


### PR DESCRIPTION
## Summary
- load `VITE_BASE_URL` via `loadEnv` and default to `/`

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c446ec7bc83258d96b70617347e40