### PR TITLE
Add flight search proxy endpoint

### DIFF
--- a/backend/src/routes/flights.js
+++ b/backend/src/routes/flights.js
@@ -1,9 +1,14 @@
 import { Router } from 'express';
-import { getFlights } from '../services/flights.js';
+import { getFlights, searchFlights } from '../services/flights.js';
 
 const router = Router();
 
 router.get('/', async (req, res) => {
+  const data = await searchFlights(req.query);
+  res.json(data);
+});
+
+router.get('/monthly', async (req, res) => {
   const data = await getFlights(req.query);
   res.json(data);
 });

--- a/backend/src/services/flights.js
+++ b/backend/src/services/flights.js
@@ -6,3 +6,13 @@ export async function getFlights(params) {
   });
   return data;
 }
+
+export async function searchFlights(params) {
+  const { data } = await axios.get(
+    'https://api.travelpayouts.com/aviasales/v3/prices_for_dates',
+    {
+      params: { ...params, token: process.env.TRAVELPAYOUTS_API_KEY },
+    },
+  );
+  return data;
+}

--- a/frontend/src/api/flights.js
+++ b/frontend/src/api/flights.js
@@ -3,3 +3,9 @@ export async function fetchFlights(params) {
   const res = await fetch(`/api/flights?${query}`);
   return res.json();
 }
+
+export async function fetchMonthlyFlights(params) {
+  const query = new URLSearchParams(params).toString();
+  const res = await fetch(`/api/flights/monthly?${query}`);
+  return res.json();
+}

--- a/frontend/src/pages/Flights.jsx
+++ b/frontend/src/pages/Flights.jsx
@@ -1,8 +1,6 @@
 import { useState } from 'react';
 import useTranslation from '../hooks/useTranslation';
-
-const API_URL = 'https://api.travelpayouts.com/aviasales/v3/prices_for_dates';
-const API_KEY = '8349af28ce9d95c3ee1635cc7729cc09';
+import { fetchFlights } from '../api/flights';
 
 export default function Flights() {
   const t = useTranslation();
@@ -28,7 +26,7 @@ export default function Flights() {
     setError('');
     setResults([]);
     try {
-      const params = new URLSearchParams({
+      const params = {
         origin: form.from,
         destination: form.to,
         departure_at: form.depart,
@@ -37,11 +35,8 @@ export default function Flights() {
         direct: 'false',
         sorting: 'price',
         limit: '30',
-        token: API_KEY,
-      });
-      const res = await fetch(`${API_URL}?${params.toString()}`);
-      if (!res.ok) throw new Error('Network error');
-      const data = await res.json();
+      };
+      const data = await fetchFlights(params);
       const flights = Array.isArray(data.data) ? data.data : [];
       if (!flights.length) {
         setError(t('flight_results') + ': 0');

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -13,5 +13,10 @@ export default defineConfig(({ mode }) => {
     plugins: [react()],
     // Use VITE_BASE_URL from the environment or fall back to root ("/")
     base: env.VITE_BASE_URL || '/',
+    server: {
+      proxy: {
+        '/api': 'http://localhost:3000',
+      },
+    },
   };
 });


### PR DESCRIPTION
## Summary
- proxy Travelpayouts API through `/api/flights`
- expose `/api/flights/monthly` for previous monthly data
- fetch flights via backend API in Flights page
- add dev proxy for backend in Vite config

## Testing
- `npm test` in `backend`
- `npm test` in `frontend` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c46b1b6a08325b9e16d7bf716d098