### PR TITLE
Add API flight proxy

### DIFF
--- a/frontend/api/flights/index.js
+++ b/frontend/api/flights/index.js
@@ -1,0 +1,18 @@
+module.exports = async (req, res) => {
+  if (req.method !== 'GET') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const token = process.env.TRAVELPAYOUTS_API_KEY || '8349af28ce9d95c3ee1635cc7729cc09';
+  const searchParams = new URLSearchParams({ ...req.query, token });
+  const url = `https://api.travelpayouts.com/aviasales/v3/prices_for_dates?${searchParams.toString()}`;
+
+  try {
+    const response = await fetch(url);
+    const data = await response.json();
+    res.status(response.status).json(data);
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to fetch flights' });
+  }
+};

--- a/frontend/api/flights/monthly.js
+++ b/frontend/api/flights/monthly.js
@@ -1,0 +1,18 @@
+module.exports = async (req, res) => {
+  if (req.method !== 'GET') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const token = process.env.TRAVELPAYOUTS_API_KEY || '8349af28ce9d95c3ee1635cc7729cc09';
+  const searchParams = new URLSearchParams({ ...req.query, token });
+  const url = `https://api.travelpayouts.com/v1/prices/monthly?${searchParams.toString()}`;
+
+  try {
+    const response = await fetch(url);
+    const data = await response.json();
+    res.status(response.status).json(data);
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to fetch flights' });
+  }
+};


### PR DESCRIPTION
## Summary
- add Vercel API route to proxy flight searches to Travelpayouts

## Testing
- `npm test` in backend
- `npm test` in frontend *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c4a7793ac8325bcbd8cffc7a1e9e5