### PR TITLE
Fix import extensions for Vercel build

### DIFF
--- a/frontend/src/pages/Contact.jsx
+++ b/frontend/src/pages/Contact.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import useTranslation from '../hooks/useTranslation';
-import { sendContact } from '../api/contact';
+import { sendContact } from '../api/contact.js';
 import SEO from '../components/SEO';
 
 export default function Contact() {

--- a/frontend/src/pages/Flights.jsx
+++ b/frontend/src/pages/Flights.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import useTranslation from '../hooks/useTranslation';
 import { fetchFlights } from '../api/flights';
 import SEO from '../components/SEO';
-import { mapToIata } from '../utils/iataMap';
+import { mapToIata } from '../utils/iataMap.js';
 
 export default function Flights() {
   const t = useTranslation();

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -4,7 +4,7 @@ import SearchBar from '../components/SearchBar';
 import { fetchFlights } from '../api/flights';
 import { fetchHotels } from '../api/hotels';
 import SEO from '../components/SEO';
-import { mapToIata } from '../utils/iataMap';
+import { mapToIata } from '../utils/iataMap.js';
 
 export default function Home() {
   const t = useTranslation();


### PR DESCRIPTION
## Summary
- specify `.js` extensions when importing custom modules

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c6579555c8325826ab10dcfadb7cc