### PR TITLE
Ensure partner token and marker for Travelpayouts API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Example environment variables
 TRAVELPAYOUTS_API_KEY=your_api_key
+TRAVELPAYOUTS_MARKER=640704
 
 # Contact form SMTP settings
 SMTP_HOST=smtp.example.com

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,4 +1,5 @@
 TRAVELPAYOUTS_API_KEY=your_api_key
+TRAVELPAYOUTS_MARKER=640704
 SMTP_HOST=smtp.example.com
 SMTP_PORT=587
 SMTP_USER=user@example.com

--- a/backend/src/services/flights.js
+++ b/backend/src/services/flights.js
@@ -17,10 +17,18 @@ Sample Travelpayouts flight response:
 }
 */
 
+const API_TOKEN = process.env.TRAVELPAYOUTS_API_KEY ||
+  '8349af28ce9d95c3ee1635cc7729cc09';
+const MARKER = process.env.TRAVELPAYOUTS_MARKER || '640704';
+
 export async function getFlights(params) {
-  const { data } = await axios.get('https://api.travelpayouts.com/v1/prices/monthly', {
-    params: { ...params, token: process.env.TRAVELPAYOUTS_API_KEY },
-  });
+  const { data } = await axios.get(
+    'https://api.travelpayouts.com/v1/prices/monthly',
+    {
+      params: { ...params, marker: MARKER },
+      headers: { 'X-Access-Token': API_TOKEN },
+    },
+  );
   return data;
 }
 
@@ -28,7 +36,8 @@ export async function searchFlights(params) {
   const { data } = await axios.get(
     'https://api.travelpayouts.com/aviasales/v3/prices_for_dates',
     {
-      params: { ...params, token: process.env.TRAVELPAYOUTS_API_KEY },
+      params: { ...params, marker: MARKER },
+      headers: { 'X-Access-Token': API_TOKEN },
     },
   );
   return data;

--- a/backend/src/services/hotels.js
+++ b/backend/src/services/hotels.js
@@ -16,9 +16,17 @@ Sample Travelpayouts hotel response:
 }
 */
 
+const API_TOKEN = process.env.TRAVELPAYOUTS_API_KEY ||
+  '8349af28ce9d95c3ee1635cc7729cc09';
+const MARKER = process.env.TRAVELPAYOUTS_MARKER || '640704';
+
 export async function getHotels(params) {
-  const { data } = await axios.get('https://api.travelpayouts.com/v1/prices/hotel-offers', {
-    params: { ...params, token: process.env.TRAVELPAYOUTS_API_KEY },
-  });
+  const { data } = await axios.get(
+    'https://api.travelpayouts.com/v1/prices/hotel-offers',
+    {
+      params: { ...params, marker: MARKER },
+      headers: { 'X-Access-Token': API_TOKEN },
+    },
+  );
   return data;
 }

--- a/frontend/api/flights/index.js
+++ b/frontend/api/flights/index.js
@@ -5,11 +5,12 @@ module.exports = async (req, res) => {
   }
 
   const token = process.env.TRAVELPAYOUTS_API_KEY || '8349af28ce9d95c3ee1635cc7729cc09';
-  const searchParams = new URLSearchParams({ ...req.query, token });
+  const marker = process.env.TRAVELPAYOUTS_MARKER || '640704';
+  const searchParams = new URLSearchParams({ ...req.query, marker });
   const url = `https://api.travelpayouts.com/aviasales/v3/prices_for_dates?${searchParams.toString()}`;
 
   try {
-    const response = await fetch(url);
+    const response = await fetch(url, { headers: { 'X-Access-Token': token } });
     const data = await response.json();
     res.status(response.status).json(data);
   } catch (error) {

--- a/frontend/api/flights/monthly.js
+++ b/frontend/api/flights/monthly.js
@@ -5,11 +5,12 @@ module.exports = async (req, res) => {
   }
 
   const token = process.env.TRAVELPAYOUTS_API_KEY || '8349af28ce9d95c3ee1635cc7729cc09';
-  const searchParams = new URLSearchParams({ ...req.query, token });
+  const marker = process.env.TRAVELPAYOUTS_MARKER || '640704';
+  const searchParams = new URLSearchParams({ ...req.query, marker });
   const url = `https://api.travelpayouts.com/v1/prices/monthly?${searchParams.toString()}`;
 
   try {
-    const response = await fetch(url);
+    const response = await fetch(url, { headers: { 'X-Access-Token': token } });
     const data = await response.json();
     res.status(response.status).json(data);
   } catch (error) {

--- a/frontend/src/pages/Flights.jsx
+++ b/frontend/src/pages/Flights.jsx
@@ -60,7 +60,12 @@ export default function Flights() {
 
   const formatDate = (d) => (d ? new Date(d).toLocaleDateString() : '');
   const getPrice = (f) => (f.price || f.value || 0) * form.passengers;
-  const getLink = (f) => f.link || f.deep_link;
+  const MARKER = '640704';
+  const getLink = (f) => {
+    const base = f.link || f.deep_link;
+    if (!base) return '';
+    return `${base}${base.includes('?') ? '&' : '?'}marker=${MARKER}`;
+  };
 
   return (
     <>

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -49,8 +49,18 @@ export default function Home() {
   };
 
   const formatDate = (d) => (d ? new Date(d).toLocaleDateString() : '');
+  const MARKER = '640704';
   const getFlightPrice = (f) => (f.price || f.value || 0);
-  const getFlightLink = (f) => f.link || f.deep_link;
+  const getFlightLink = (f) => {
+    const base = f.link || f.deep_link;
+    if (!base) return '';
+    return `${base}${base.includes('?') ? '&' : '?'}marker=${MARKER}`;
+  };
+  const getHotelLink = (h) => {
+    if (!h.link) return '';
+    const base = h.link;
+    return `${base}${base.includes('?') ? '&' : '?'}marker=${MARKER}`;
+  };
 
   return (
     <>
@@ -112,9 +122,9 @@ export default function Home() {
               </div>
               <div className="flex items-center mt-2 sm:mt-0 gap-4">
                 <span className="font-bold text-blue-600">${hotel.price || hotel.price_from}</span>
-                {hotel.link && (
+                {getHotelLink(hotel) && (
                   <a
-                    href={hotel.link}
+                    href={getHotelLink(hotel)}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="bg-green-600 text-white px-3 py-1 rounded"


### PR DESCRIPTION
## Summary
- ensure all API requests send `X-Access-Token` header and `marker=640704`
- append the partner marker to booking links
- document the marker in `.env.example`

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_685c7cb167f083258b29bd6a64c836a3