### PR TITLE
Update search APIs to call Travelpayouts directly

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,5 @@ CONTACT_TO=contact@example.com
 # Frontend environment
 VITE_BASE_URL=/Travelia/
 VITE_GA_ID=G-XXXXXXX
+VITE_TRAVELPAYOUTS_API_KEY=your_api_key
+VITE_TRAVELPAYOUTS_MARKER=640704

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The Express backend includes `vercel.json` so it can be deployed to Vercel. You 
 
 ## Custom API Keys and Images
 
-Add your Travelpayouts API key and other secrets to the `.env` files. Replace the placeholder images in `frontend/public` or `frontend/src/assets` with your own assets.
+Add your Travelpayouts API key and other secrets to the `.env` files. The frontend reads `VITE_TRAVELPAYOUTS_API_KEY` and `VITE_TRAVELPAYOUTS_MARKER` to query the Travelpayouts API directly. Replace the placeholder images in `frontend/public` or `frontend/src/assets` with your own assets.
 
 ---
 

--- a/frontend/src/api/flights.js
+++ b/frontend/src/api/flights.js
@@ -1,11 +1,24 @@
+const API_TOKEN = import.meta.env.VITE_TRAVELPAYOUTS_API_KEY;
+const MARKER = import.meta.env.VITE_TRAVELPAYOUTS_MARKER;
+
 export async function fetchFlights(params) {
-  const query = new URLSearchParams(params).toString();
-  const res = await fetch(`/api/flights?${query}`);
+  const query = new URLSearchParams({ ...params, marker: MARKER }).toString();
+  const res = await fetch(
+    `https://api.travelpayouts.com/aviasales/v3/prices_for_dates?${query}`,
+    {
+      headers: { 'X-Access-Token': API_TOKEN },
+    },
+  );
   return res.json();
 }
 
 export async function fetchMonthlyFlights(params) {
-  const query = new URLSearchParams(params).toString();
-  const res = await fetch(`/api/flights/monthly?${query}`);
+  const query = new URLSearchParams({ ...params, marker: MARKER }).toString();
+  const res = await fetch(
+    `https://api.travelpayouts.com/v1/prices/monthly?${query}`,
+    {
+      headers: { 'X-Access-Token': API_TOKEN },
+    },
+  );
   return res.json();
 }

--- a/frontend/src/api/hotels.js
+++ b/frontend/src/api/hotels.js
@@ -1,5 +1,13 @@
+const API_TOKEN = import.meta.env.VITE_TRAVELPAYOUTS_API_KEY;
+const MARKER = import.meta.env.VITE_TRAVELPAYOUTS_MARKER;
+
 export async function fetchHotels(params) {
-  const query = new URLSearchParams(params).toString();
-  const res = await fetch(`/api/hotels?${query}`);
+  const query = new URLSearchParams({ ...params, marker: MARKER }).toString();
+  const res = await fetch(
+    `https://api.travelpayouts.com/v1/prices/hotel-offers?${query}`,
+    {
+      headers: { 'X-Access-Token': API_TOKEN },
+    },
+  );
   return res.json();
 }


### PR DESCRIPTION
## Summary
- call Travelpayouts API directly from the frontend
- expose the API key and marker to the frontend via environment variables
- document new variables in README

## Testing
- `npm test` (frontend)
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_685c833967048325a0b7f4f5124e408f