### PR TITLE
Fix flight search CORS by using backend proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,5 +12,3 @@ CONTACT_TO=contact@example.com
 # Frontend environment
 VITE_BASE_URL=/Travelia/
 VITE_GA_ID=G-XXXXXXX
-VITE_TRAVELPAYOUTS_API_KEY=your_api_key
-VITE_TRAVELPAYOUTS_MARKER=640704

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The Express backend includes `vercel.json` so it can be deployed to Vercel. You 
 
 ## Custom API Keys and Images
 
-Add your Travelpayouts API key and other secrets to the `.env` files. The frontend reads `VITE_TRAVELPAYOUTS_API_KEY` and `VITE_TRAVELPAYOUTS_MARKER` to query the Travelpayouts API directly. Replace the placeholder images in `frontend/public` or `frontend/src/assets` with your own assets.
+Add your Travelpayouts API key and other secrets to the `.env` file. The backend reads `TRAVELPAYOUTS_API_KEY` and `TRAVELPAYOUTS_MARKER` to query the Travelpayouts API. The frontend calls the proxy endpoints under `/api` so the keys remain private. Replace the placeholder images in `frontend/public` or `frontend/src/assets` with your own assets.
 
 ---
 

--- a/frontend/src/api/flights.js
+++ b/frontend/src/api/flights.js
@@ -1,24 +1,11 @@
-const API_TOKEN = import.meta.env.VITE_TRAVELPAYOUTS_API_KEY;
-const MARKER = import.meta.env.VITE_TRAVELPAYOUTS_MARKER;
-
 export async function fetchFlights(params) {
-  const query = new URLSearchParams({ ...params, marker: MARKER }).toString();
-  const res = await fetch(
-    `https://api.travelpayouts.com/aviasales/v3/prices_for_dates?${query}`,
-    {
-      headers: { 'X-Access-Token': API_TOKEN },
-    },
-  );
+  const query = new URLSearchParams(params).toString();
+  const res = await fetch(`/api/flights?${query}`);
   return res.json();
 }
 
 export async function fetchMonthlyFlights(params) {
-  const query = new URLSearchParams({ ...params, marker: MARKER }).toString();
-  const res = await fetch(
-    `https://api.travelpayouts.com/v1/prices/monthly?${query}`,
-    {
-      headers: { 'X-Access-Token': API_TOKEN },
-    },
-  );
+  const query = new URLSearchParams(params).toString();
+  const res = await fetch(`/api/flights/monthly?${query}`);
   return res.json();
 }

--- a/frontend/src/api/hotels.js
+++ b/frontend/src/api/hotels.js
@@ -1,13 +1,5 @@
-const API_TOKEN = import.meta.env.VITE_TRAVELPAYOUTS_API_KEY;
-const MARKER = import.meta.env.VITE_TRAVELPAYOUTS_MARKER;
-
 export async function fetchHotels(params) {
-  const query = new URLSearchParams({ ...params, marker: MARKER }).toString();
-  const res = await fetch(
-    `https://api.travelpayouts.com/v1/prices/hotel-offers?${query}`,
-    {
-      headers: { 'X-Access-Token': API_TOKEN },
-    },
-  );
+  const query = new URLSearchParams(params).toString();
+  const res = await fetch(`/api/hotels?${query}`);
   return res.json();
 }


### PR DESCRIPTION
## Summary
- send flight and hotel search requests through the backend
- remove Travelpayouts keys from client environment
- document the backend proxy in the readme

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_685c8e7bfc6c8325ad8f80a39d9f05b9