### PR TITLE
Improve hotel search bar with autocomplete

### DIFF
--- a/frontend/src/assets/cities.json
+++ b/frontend/src/assets/cities.json
@@ -1,0 +1,22 @@
+[
+  {"city": "Tel Aviv", "country": "Israel", "hebrew_city": "תל אביב"},
+  {"city": "Jerusalem", "country": "Israel", "hebrew_city": "ירושלים"},
+  {"city": "London", "country": "United Kingdom", "hebrew_city": "לונדון"},
+  {"city": "Paris", "country": "France", "hebrew_city": "פריז"},
+  {"city": "New York", "country": "USA", "hebrew_city": "ניו יורק"},
+  {"city": "Los Angeles", "country": "USA", "hebrew_city": "לוס אנג'לס"},
+  {"city": "Rome", "country": "Italy", "hebrew_city": "רומא"},
+  {"city": "Berlin", "country": "Germany", "hebrew_city": "ברלין"},
+  {"city": "Tokyo", "country": "Japan", "hebrew_city": "טוקיו"},
+  {"city": "Bangkok", "country": "Thailand", "hebrew_city": "בנגקוק"},
+  {"city": "Barcelona", "country": "Spain", "hebrew_city": "ברצלונה"},
+  {"city": "Madrid", "country": "Spain", "hebrew_city": "מדריד"},
+  {"city": "Moscow", "country": "Russia", "hebrew_city": "מוסקבה"},
+  {"city": "Beijing", "country": "China", "hebrew_city": "בייג׳ינג"},
+  {"city": "Sydney", "country": "Australia", "hebrew_city": "סידני"},
+  {"city": "Toronto", "country": "Canada", "hebrew_city": "טורונטו"},
+  {"city": "Buenos Aires", "country": "Argentina", "hebrew_city": "בואנוס איירס"},
+  {"city": "Mexico City", "country": "Mexico", "hebrew_city": "מקסיקו סיטי"},
+  {"city": "Cape Town", "country": "South Africa", "hebrew_city": "קייפטאון"},
+  {"city": "Dubai", "country": "UAE", "hebrew_city": "דובאי"}
+]

--- a/frontend/src/components/CityAutocomplete.jsx
+++ b/frontend/src/components/CityAutocomplete.jsx
@@ -1,0 +1,99 @@
+import { useState, useEffect, useRef } from 'react';
+import cities from '../assets/cities.json';
+import useTranslation from '../hooks/useTranslation';
+
+export default function CityAutocomplete({ name, value, onChange, placeholder, className = 'w-full rounded-xl border px-3 py-2' }) {
+  const t = useTranslation();
+  const [query, setQuery] = useState(value || '');
+  const [results, setResults] = useState([]);
+  const [active, setActive] = useState(-1);
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef(null);
+
+  useEffect(() => {
+    setQuery(value || '');
+  }, [value]);
+
+  useEffect(() => {
+    if (query && query.length >= 2) {
+      const lower = query.toLowerCase();
+      const filtered = cities.filter(c =>
+        c.city.toLowerCase().includes(lower) ||
+        (c.hebrew_city && c.hebrew_city.includes(query)) ||
+        (c.country && c.country.toLowerCase().includes(lower))
+      ).slice(0, 10);
+      setResults(filtered);
+      setOpen(true);
+    } else {
+      setResults([]);
+      setOpen(false);
+    }
+    setActive(-1);
+  }, [query]);
+
+  useEffect(() => {
+    const handleClick = (e) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('click', handleClick);
+    return () => document.removeEventListener('click', handleClick);
+  }, []);
+
+  const onInputChange = (e) => {
+    setQuery(e.target.value);
+    onChange && onChange(e);
+  };
+
+  const select = (city) => {
+    const val = city.city;
+    setQuery(val);
+    setOpen(false);
+    onChange && onChange({ target: { name, value: val } });
+  };
+
+  const onKeyDown = (e) => {
+    if (!open) return;
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActive((prev) => (prev < results.length - 1 ? prev + 1 : prev));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActive((prev) => (prev > 0 ? prev - 1 : -1));
+    } else if (e.key === 'Enter' && active >= 0) {
+      e.preventDefault();
+      select(results[active]);
+    }
+  };
+
+  return (
+    <div className="relative" ref={wrapperRef}>
+      <input
+        autoComplete="off"
+        name={name}
+        value={query}
+        onChange={onInputChange}
+        onKeyDown={onKeyDown}
+        placeholder={placeholder}
+        className={className}
+      />
+      {open && (
+        <ul className="absolute z-10 w-full bg-white border rounded shadow mt-1 max-h-60 overflow-auto rtl:right-0 rtl:text-right">
+          {results.length === 0 && (
+            <li className="p-2 text-gray-500">{t('no_results')}</li>
+          )}
+          {results.map((c, idx) => (
+            <li
+              key={`${c.city}-${idx}`}
+              onClick={() => select(c)}
+              className={`p-2 cursor-pointer hover:bg-blue-50 ${idx === active ? 'bg-blue-100' : ''}`}
+            >
+              <span className="font-semibold">{c.city}</span>{c.country ? `, ${c.country}` : ''}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/Hotels.jsx
+++ b/frontend/src/pages/Hotels.jsx
@@ -4,6 +4,9 @@ import { fetchHotels } from '../api/hotels';
 import { DealsContext } from '../contexts/DealsContext';
 import SEO from '../components/SEO';
 import HotelIcon from '../components/HotelIcon';
+import CalendarIcon from '../components/CalendarIcon';
+import UserIcon from '../components/UserIcon';
+import CityAutocomplete from '../components/CityAutocomplete';
 
 export default function Hotels() {
   const t = useTranslation();
@@ -11,11 +14,13 @@ export default function Hotels() {
   const [form, setForm] = useState({ city: '', check_in: '', check_out: '', guests: 1, rooms: 1 });
   const [results, setResults] = useState([]);
   const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
 
   const handleChange = (e) => setForm({ ...form, [e.target.name]: e.target.value });
 
   const search = async () => {
     try {
+      setLoading(true);
       setError('');
       setResults([]);
       const data = await fetchHotels(form);
@@ -23,6 +28,8 @@ export default function Hotels() {
       else setResults(data.data);
     } catch {
       setError('Error');
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -31,14 +38,71 @@ export default function Hotels() {
       <SEO title={t('hotels')} description="Search hotels" />
       <div className="space-y-4">
         <h2 className="text-xl font-bold">{t('hotels')}</h2>
-      <div className="grid grid-cols-2 md:grid-cols-5 gap-2">
-        <input className="border p-2" name="city" onChange={handleChange} placeholder={t('hotel_city')} />
-        <input className="border p-2" type="date" name="check_in" onChange={handleChange} />
-        <input className="border p-2" type="date" name="check_out" onChange={handleChange} />
-        <input className="border p-2" type="number" name="guests" min="1" onChange={handleChange} placeholder={t('guests')} />
-        <input className="border p-2" type="number" name="rooms" min="1" onChange={handleChange} placeholder={t('rooms')} />
-      </div>
-      <button className="bg-blue-600 text-white px-4 py-2" onClick={search}>{t('search')}</button>
+      <form onSubmit={(e) => { e.preventDefault(); search(); }}>
+        <div className="flex flex-col md:flex-row gap-3 p-4 bg-white shadow rounded-2xl items-center max-w-3xl mx-auto">
+          <div className="relative flex-1 w-full">
+            <HotelIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500" />
+            <CityAutocomplete
+              className="w-full rounded-xl border px-3 py-2 pl-9"
+              name="city"
+              value={form.city}
+              onChange={handleChange}
+              placeholder={`${t('hotel_city')} (Paris)`}
+            />
+          </div>
+          <div className="relative w-full">
+            <CalendarIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500" />
+            <input
+              className="w-full rounded-xl border px-3 py-2 pl-9"
+              type="date"
+              name="check_in"
+              value={form.check_in}
+              onChange={handleChange}
+              required
+            />
+          </div>
+          <div className="relative w-full">
+            <CalendarIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500" />
+            <input
+              className="w-full rounded-xl border px-3 py-2 pl-9"
+              type="date"
+              name="check_out"
+              value={form.check_out}
+              onChange={handleChange}
+              required
+            />
+          </div>
+          <div className="relative w-full md:w-24">
+            <UserIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500" />
+            <input
+              className="w-full rounded-xl border px-3 py-2 pl-9"
+              type="number"
+              name="guests"
+              min="1"
+              value={form.guests}
+              onChange={handleChange}
+            />
+          </div>
+          <div className="relative w-full md:w-24">
+            <HotelIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500" />
+            <input
+              className="w-full rounded-xl border px-3 py-2 pl-9"
+              type="number"
+              name="rooms"
+              min="1"
+              value={form.rooms}
+              onChange={handleChange}
+            />
+          </div>
+          <button
+            type="submit"
+            className="bg-blue-600 text-white font-bold rounded-xl px-6 py-2 hover:bg-blue-700 transition w-full md:w-auto"
+            disabled={loading}
+          >
+            {loading ? t('searching') || 'Searching...' : t('search')}
+          </button>
+        </div>
+      </form>
       <a
         href="https://www.trip.com/?Allianceid=6645150&SID=227505580&trip_sub1=&trip_sub3=D4181669"
         target="_blank"


### PR DESCRIPTION
## Summary
- add a list of cities for autocomplete
- create `CityAutocomplete` component similar to the airport picker
- redesign the Hotels page search form with icons and autocompletion

## Testing
- `npm --prefix frontend test`
- `npm --prefix backend test`


------
https://chatgpt.com/codex/tasks/task_e_685c91ec27508325a2b633e70c713d9b