### PR TITLE
Fix Travelpayouts token query param

### DIFF
--- a/backend/src/services/flights.js
+++ b/backend/src/services/flights.js
@@ -25,8 +25,7 @@ export async function getFlights(params) {
   const { data } = await axios.get(
     'https://api.travelpayouts.com/v1/prices/monthly',
     {
-      params: { ...params, marker: MARKER },
-      headers: { 'X-Access-Token': API_TOKEN },
+      params: { ...params, marker: MARKER, token: API_TOKEN },
     },
   );
   return data;
@@ -36,8 +35,7 @@ export async function searchFlights(params) {
   const { data } = await axios.get(
     'https://api.travelpayouts.com/aviasales/v3/prices_for_dates',
     {
-      params: { ...params, marker: MARKER },
-      headers: { 'X-Access-Token': API_TOKEN },
+      params: { ...params, marker: MARKER, token: API_TOKEN },
     },
   );
   return data;

--- a/backend/src/services/hotels.js
+++ b/backend/src/services/hotels.js
@@ -24,8 +24,7 @@ export async function getHotels(params) {
   const { data } = await axios.get(
     'https://api.travelpayouts.com/v1/prices/hotel-offers',
     {
-      params: { ...params, marker: MARKER },
-      headers: { 'X-Access-Token': API_TOKEN },
+      params: { ...params, marker: MARKER, token: API_TOKEN },
     },
   );
   return data;

--- a/frontend/api/flights/index.js
+++ b/frontend/api/flights/index.js
@@ -6,11 +6,11 @@ module.exports = async (req, res) => {
 
   const token = process.env.TRAVELPAYOUTS_API_KEY || '8349af28ce9d95c3ee1635cc7729cc09';
   const marker = process.env.TRAVELPAYOUTS_MARKER || '640704';
-  const searchParams = new URLSearchParams({ ...req.query, marker });
+  const searchParams = new URLSearchParams({ ...req.query, marker, token });
   const url = `https://api.travelpayouts.com/aviasales/v3/prices_for_dates?${searchParams.toString()}`;
 
   try {
-    const response = await fetch(url, { headers: { 'X-Access-Token': token } });
+    const response = await fetch(url);
     const data = await response.json();
     res.status(response.status).json(data);
   } catch (error) {

--- a/frontend/api/flights/monthly.js
+++ b/frontend/api/flights/monthly.js
@@ -6,11 +6,11 @@ module.exports = async (req, res) => {
 
   const token = process.env.TRAVELPAYOUTS_API_KEY || '8349af28ce9d95c3ee1635cc7729cc09';
   const marker = process.env.TRAVELPAYOUTS_MARKER || '640704';
-  const searchParams = new URLSearchParams({ ...req.query, marker });
+  const searchParams = new URLSearchParams({ ...req.query, marker, token });
   const url = `https://api.travelpayouts.com/v1/prices/monthly?${searchParams.toString()}`;
 
   try {
-    const response = await fetch(url, { headers: { 'X-Access-Token': token } });
+    const response = await fetch(url);
     const data = await response.json();
     res.status(response.status).json(data);
   } catch (error) {


### PR DESCRIPTION
## Summary
- include Travelpayouts `token` parameter when calling flights and hotels endpoints
- remove use of `X-Access-Token` header in serverless API wrappers

## Testing
- `npm test --silent --prefix backend`
- `npm test --silent --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_685c9573ad708325957d45425632dba5