### PR TITLE
Enable SPA routing with React Router

### DIFF
--- a/backend/src/services/flights.js
+++ b/backend/src/services/flights.js
@@ -25,7 +25,13 @@ export async function getFlights(params) {
   const { data } = await axios.get(
     'https://api.travelpayouts.com/v1/prices/monthly',
     {
-      params: { ...params, marker: MARKER, token: API_TOKEN },
+      params: {
+        currency: 'USD',
+        locale: 'en-US',
+        ...params,
+        marker: MARKER,
+        token: API_TOKEN,
+      },
     },
   );
   return data;
@@ -35,7 +41,13 @@ export async function searchFlights(params) {
   const { data } = await axios.get(
     'https://api.travelpayouts.com/aviasales/v3/prices_for_dates',
     {
-      params: { ...params, marker: MARKER, token: API_TOKEN },
+      params: {
+        currency: 'USD',
+        locale: 'en-US',
+        ...params,
+        marker: MARKER,
+        token: API_TOKEN,
+      },
     },
   );
   return data;

--- a/backend/src/services/hotels.js
+++ b/backend/src/services/hotels.js
@@ -24,7 +24,13 @@ export async function getHotels(params) {
   const { data } = await axios.get(
     'https://api.travelpayouts.com/v1/prices/hotel-offers',
     {
-      params: { ...params, marker: MARKER, token: API_TOKEN },
+      params: {
+        currency: 'USD',
+        locale: 'en-US',
+        ...params,
+        marker: MARKER,
+        token: API_TOKEN,
+      },
     },
   );
   return data;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.14.1",
     "react-helmet": "^6.1.0",
     "react-date-range": "^1.4.0",
     "date-fns": "^2.30.0"

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,5 @@
-import { useState, useContext } from 'react';
+import { useContext } from 'react';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Header from './components/Header';
 import Footer from './components/Footer';
 import Home from './pages/Home';
@@ -7,43 +8,39 @@ import Hotels from './pages/Hotels';
 import Deals from './pages/Deals';
 import Blog from './pages/Blog';
 import Contact from './pages/Contact';
+import NotFound from './pages/NotFound';
 import { LanguageProvider, LanguageContext } from './contexts/LanguageContext';
 import { DealsProvider } from './contexts/DealsContext';
 
-const pages = {
-  home: Home,
-  flights: Flights,
-  hotels: Hotels,
-  deals: Deals,
-  blog: Blog,
-  contact: Contact,
-};
-
-function PageRenderer({ page }) {
-  const Component = pages[page] || Home;
-  return <Component />;
-}
-
 export default function App() {
-  const [page, setPage] = useState('home');
   return (
     <LanguageProvider>
       <DealsProvider>
-        <InnerApp page={page} setPage={setPage} />
+        <InnerApp />
       </DealsProvider>
     </LanguageProvider>
   );
 }
 
-function InnerApp({ page, setPage }) {
+function InnerApp() {
   const { language } = useContext(LanguageContext);
   return (
-    <div className="flex flex-col min-h-screen" dir={language === 'he' ? 'rtl' : 'ltr'}>
-      <Header onNavigate={setPage} />
-      <main className="flex-1 p-4">
-        <PageRenderer page={page} />
-      </main>
-      <Footer />
-    </div>
+    <Router>
+      <div className="flex flex-col min-h-screen" dir={language === 'he' ? 'rtl' : 'ltr'}>
+        <Header />
+        <main className="flex-1 p-4">
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/flights" element={<Flights />} />
+            <Route path="/hotels" element={<Hotels />} />
+            <Route path="/deals" element={<Deals />} />
+            <Route path="/blog" element={<Blog />} />
+            <Route path="/contact" element={<Contact />} />
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </main>
+        <Footer />
+      </div>
+    </Router>
   );
 }

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,19 +1,23 @@
 import { useContext, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { LanguageContext } from '../contexts/LanguageContext';
 import useTranslation from '../hooks/useTranslation';
 
-export default function Header({ onNavigate }) {
+export default function Header() {
   const { language, setLanguage } = useContext(LanguageContext);
   const t = useTranslation();
   const [menuOpen, setMenuOpen] = useState(false);
-  const pages = ['home', 'flights', 'hotels', 'deals', 'blog', 'contact'];
+  const pages = [
+    { name: 'home', path: '/' },
+    { name: 'flights', path: '/flights' },
+    { name: 'hotels', path: '/hotels' },
+    { name: 'deals', path: '/deals' },
+    { name: 'blog', path: '/blog' },
+    { name: 'contact', path: '/contact' },
+  ];
   const isRTL = language === 'he';
 
   const toggleMenu = () => setMenuOpen((v) => !v);
-  const navigate = (p) => {
-    onNavigate(p);
-    setMenuOpen(false);
-  };
 
   return (
     <header className="bg-blue-600 text-white shadow">
@@ -48,13 +52,14 @@ export default function Header({ onNavigate }) {
           } w-full flex-col gap-2 mt-2 md:mt-0 md:flex md:w-auto ${isRTL ? 'md:flex-row-reverse' : 'md:flex-row'} md:items-center`}
         >
           {pages.map((p) => (
-            <button
-              key={p}
-              onClick={() => navigate(p)}
+            <Link
+              key={p.path}
+              to={p.path}
+              onClick={() => setMenuOpen(false)}
               className="px-3 py-1 hover:underline text-left md:text-center"
             >
-              {t(p)}
-            </button>
+              {t(p.name)}
+            </Link>
           ))}
         </nav>
         <select

--- a/frontend/src/pages/Flights.jsx
+++ b/frontend/src/pages/Flights.jsx
@@ -3,6 +3,7 @@ import useTranslation from '../hooks/useTranslation';
 import { fetchFlights } from '../api/flights';
 import SEO from '../components/SEO';
 import { mapToIata } from '../utils/iataMap';
+import { formatPrice } from '../utils/formatPrice';
 import FlightIcon from '../components/FlightIcon';
 import CalendarIcon from '../components/CalendarIcon';
 import UserIcon from '../components/UserIcon';
@@ -158,7 +159,7 @@ export default function Flights() {
                 </p>
               </div>
               <div className="flex items-center mt-2 sm:mt-0 gap-4">
-                <span className="font-bold text-blue-600">${getPrice(flight)}</span>
+                <span className="font-bold text-blue-600">{formatPrice(getPrice(flight))}</span>
                 {getLink(flight) && (
                   <a
                     href={getLink(flight)}

--- a/frontend/src/pages/Hotels.jsx
+++ b/frontend/src/pages/Hotels.jsx
@@ -7,6 +7,7 @@ import HotelIcon from '../components/HotelIcon';
 import CalendarIcon from '../components/CalendarIcon';
 import UserIcon from '../components/UserIcon';
 import CityAutocomplete from '../components/CityAutocomplete';
+import { formatPrice } from '../utils/formatPrice';
 
 export default function Hotels() {
   const t = useTranslation();
@@ -124,8 +125,13 @@ export default function Hotels() {
       {error && <p className="text-red-600">{error}</p>}
       <ul className="space-y-2">
         {results.map((h, i) => (
-          <li key={i} className="border p-2 flex justify-between items-center">
-            <span>{h.name} - {h.price}</span>
+          <li key={i} className="border p-2 flex justify-between items-center gap-4">
+            {h.photo && (
+              <img src={h.photo} alt={h.name} className="w-24 h-16 object-cover rounded" />
+            )}
+            <span className="flex-1">
+              {h.name} - {formatPrice(h.price || h.price_from)}
+            </span>
             <button className="bg-green-600 text-white px-2" onClick={() => addDeal(null, h)}>{t('add_deal')}</button>
           </li>
         ))}

--- a/frontend/src/utils/formatPrice.js
+++ b/frontend/src/utils/formatPrice.js
@@ -1,0 +1,8 @@
+export function formatPrice(value, currency = 'USD') {
+  if (value === undefined || value === null) return '';
+  return new Intl.NumberFormat(undefined, {
+    style: 'currency',
+    currency,
+    maximumFractionDigits: 0,
+  }).format(Number(value));
+}

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
## Summary
- route all frontend pages with React Router
- update navigation to use `<Link>`
- add SPA rewrite configuration for Vercel
- format prices with new helper and show hotel images
- pass locale and currency params to API calls

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_685c9810ad9c832590d89bff7ad844b5