### PR TITLE
Improve hotel search handling

### DIFF
--- a/frontend/src/components/LoadingSpinner.jsx
+++ b/frontend/src/components/LoadingSpinner.jsx
@@ -1,0 +1,3 @@
+export default function LoadingSpinner({ className = 'w-6 h-6 border-4 border-blue-500 border-t-transparent rounded-full animate-spin' }) {
+  return <div className={className}></div>;
+}

--- a/frontend/src/utils/cityMap.js
+++ b/frontend/src/utils/cityMap.js
@@ -1,0 +1,14 @@
+export const hebrewToCity = {
+  'תל אביב': 'Tel Aviv',
+  'חיפה': 'Haifa',
+  'אילת': 'Eilat',
+  'לונדון': 'London',
+  'ניו יורק': 'New York',
+};
+
+export function mapToCity(value) {
+  const trimmed = value.trim();
+  const match = trimmed.match(/\(([^)]+)\)$/);
+  if (match) return match[1];
+  return hebrewToCity[trimmed] || trimmed;
+}


### PR DESCRIPTION
## Summary
- add new `LoadingSpinner` component
- map Hebrew city names to English
- show spinner and user-friendly messages on the hotel page
- log hotel API responses for easier debugging

## Testing
- `npm test --prefix frontend`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_685d044bab2483258fa7d9796c78d6d9