### PR TITLE
Add deploy script for GitHub Pages

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Deploy built frontend to GitHub Pages
+set -e
+
+# Build the project
+cd frontend
+npm run build
+
+# Initialize a git repo inside the build directory
+cd dist
+git init
+git checkout -b gh-pages
+# Configure the correct remote
+git remote add origin https://github.com/Shayfly/Travelia.git
+
+# Commit and push the contents
+git add -A
+git commit -m "Deploy to GitHub Pages"
+
+git push -f origin gh-pages
+
+# Clean up the temporary git directory
+cd ..
+rm -rf dist/.git
+cd ..
+
+echo "Deployment complete."


### PR DESCRIPTION
## Summary
- add a deploy.sh script to push `frontend/dist` to `gh-pages`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d3fa9562083259d82368c480d1d59