### PR TITLE
Fix layout and header

### DIFF
--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -1,15 +1,33 @@
 import { useContext } from 'react';
 import { LanguageContext } from '../contexts/LanguageContext';
+import { NavLink } from 'react-router-dom';
+import useTranslation from '../hooks/useTranslation';
 
 export default function Footer() {
   const { language } = useContext(LanguageContext);
+  const t = useTranslation();
+  const pages = [
+    { name: 'home', path: '/' },
+    { name: 'flights', path: '/flights' },
+    { name: 'hotels', path: '/hotels' },
+    { name: 'deals', path: '/deals' },
+    { name: 'contact', path: '/contact' },
+  ];
+
   return (
-    <footer className="bg-gray-200 text-sm">
+    <footer className="bg-gray-200 text-sm mt-auto">
       <div
-        className="container mx-auto p-4 text-center"
+        className="max-w-screen-xl mx-auto px-4 py-4 flex flex-col md:flex-row justify-between items-center gap-2"
         dir={language === 'he' ? 'rtl' : 'ltr'}
       >
-        &copy; {new Date().getFullYear()} Travelia
+        <span>&copy; {new Date().getFullYear()} Travelia</span>
+        <nav className="flex gap-3 flex-wrap">
+          {pages.map((p) => (
+            <NavLink key={p.path} to={p.path} className="hover:underline">
+              {t(p.name)}
+            </NavLink>
+          ))}
+        </nav>
       </div>
     </footer>
   );

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,9 +1,8 @@
 import { useContext, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { NavLink } from 'react-router-dom';
 import { LanguageContext } from '../contexts/LanguageContext';
 import useTranslation from '../hooks/useTranslation';
 
-// ודא שקובץ Travelia_Logo.png קיים בתיקייה public/assets
 const TraveliaLogo = '/assets/Travelia_Logo.png';
 
 export default function Header() {
@@ -29,35 +28,30 @@ export default function Header() {
   return (
     <header className="bg-primary text-white shadow">
       <div
-        className={`container mx-auto flex flex-wrap items-center justify-between p-4 ${
+        className={`max-w-screen-xl mx-auto px-4 flex flex-wrap items-center justify-between p-4 ${
           isRTL ? 'md:flex-row-reverse' : ''
         }`}
       >
-        {/* לוגו וסלוגן */}
+        {/* Logo and slogan */}
         <div className="flex items-center gap-3">
           <img src={TraveliaLogo} alt="Travelia logo" className="h-10 w-10" />
-          <h1 className="text-sm md:text-base font-bold whitespace-nowrap">
+          <p className="text-sm md:text-base font-bold whitespace-nowrap">
             {slogans[language]}
-          </h1>
+          </p>
         </div>
 
-        {/* תפריט נייד */}
+        {/* Mobile menu toggle */}
         <button
           className="md:hidden ml-auto text-white"
           onClick={() => setMenuOpen(!menuOpen)}
           aria-label="Toggle navigation"
         >
-          <svg
-            className="w-6 h-6"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
+          <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
           </svg>
         </button>
 
-        {/* ניווט */}
+        {/* Navigation */}
         <nav
           className={`${
             menuOpen ? 'flex' : 'hidden'
@@ -66,8 +60,27 @@ export default function Header() {
           } md:items-center`}
         >
           {pages.map((p) => (
-            <Link
+            <NavLink
               key={p.path}
               to={p.path}
               onClick={() => setMenuOpen(false)}
-              className="px-3 py-1 hover:u
+              className={({ isActive }) =>
+                `px-3 py-1 hover:underline ${isActive ? 'font-semibold' : ''}`
+              }
+            >
+              {t(p.name)}
+            </NavLink>
+          ))}
+          <select
+            value={language}
+            onChange={(e) => setLanguage(e.target.value)}
+            className="ml-2 text-black rounded px-2 py-1"
+          >
+            <option value="en">EN</option>
+            <option value="he">HE</option>
+          </select>
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/frontend/src/components/HeroSearchBar.jsx
+++ b/frontend/src/components/HeroSearchBar.jsx
@@ -58,7 +58,7 @@ export default function HeroSearchBar({ onSearch, type = 'flight', showTripType 
   };
 
   return (
-    <form onSubmit={submit} className="max-w-screen md:max-w-7xl mx-auto mt-4 overflow-hidden">
+    <form onSubmit={submit} className="max-w-screen-xl mx-auto mt-4 overflow-hidden">
       <div className="grid grid-cols-1 md:grid-cols-6 gap-3 p-4 rounded-2xl bg-white shadow items-end">
         {type === 'flight' && showTripType && (
           <div className="flex gap-2 items-center col-span-full rtl:flex-row-reverse">

--- a/frontend/src/pages/Blog.jsx
+++ b/frontend/src/pages/Blog.jsx
@@ -12,7 +12,7 @@ export default function Blog() {
   return (
     <>
       <SEO title="Blog" description="Travelia blog" />
-      <div className="space-y-4">
+      <div className="space-y-4 max-w-screen-xl mx-auto px-4">
       <h2 className="text-xl font-bold">{t('blog_title')}</h2>
       {posts.map((p, i) => (
         <article key={i} className="border p-2">

--- a/frontend/src/pages/Contact.jsx
+++ b/frontend/src/pages/Contact.jsx
@@ -24,7 +24,7 @@ export default function Contact() {
   return (
     <>
       <SEO title={t('contact')} description="Contact Travelia" />
-      <div className="space-y-4 max-w-md mx-auto">
+      <div className="space-y-4 max-w-md mx-auto px-4">
       <h2 className="text-xl font-bold">{t('contact')}</h2>
       {sent ? (
         <p className="text-green-600">{t('message')}</p>

--- a/frontend/src/pages/Deals.jsx
+++ b/frontend/src/pages/Deals.jsx
@@ -9,7 +9,7 @@ export default function Deals() {
   return (
     <>
       <SEO title={t('deals')} description="Saved deals" />
-      <div className="space-y-4">
+      <div className="space-y-4 max-w-screen-xl mx-auto px-4">
         <h2 className="text-xl font-bold">{t('deals_list')}</h2>
       <ul className="space-y-2">
         {deals.map((d, i) => (

--- a/frontend/src/pages/Flights.jsx
+++ b/frontend/src/pages/Flights.jsx
@@ -67,7 +67,7 @@ export default function Flights() {
   return (
     <>
       <SEO title={t('flights')} description="Search flights" />
-      <div className="space-y-6 overflow-hidden max-w-screen md:max-w-7xl mx-auto">
+      <div className="space-y-6 overflow-hidden max-w-screen-xl mx-auto px-4">
         <h2 className="text-xl font-bold">{t('flights')}</h2>
 
         <HeroSearchBar type="flight" showTripType={true} onSearch={searchFlights} />

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -69,7 +69,7 @@ export default function Home() {
   return (
     <>
       <SEO title="Travelia" description="Search flights and hotels" />
-      <div className="p-4 space-y-6">
+      <div className="space-y-6 max-w-screen-xl mx-auto px-4">
         <div className="flex justify-center mt-8">
           <img
             src={logo}

--- a/frontend/src/pages/Hotels.jsx
+++ b/frontend/src/pages/Hotels.jsx
@@ -51,7 +51,7 @@ export default function Hotels() {
   return (
     <>
       <SEO title={t('hotels')} description="Search hotels" />
-      <div className="space-y-4 overflow-hidden max-w-screen md:max-w-7xl mx-auto">
+      <div className="space-y-4 overflow-hidden max-w-screen-xl mx-auto px-4">
         <h2 className="text-xl font-bold">{t('hotels')}</h2>
 
         <HeroSearchBar type="hotel" showTripType={false} onSearch={search} />

--- a/frontend/src/pages/NotFound.jsx
+++ b/frontend/src/pages/NotFound.jsx
@@ -1,6 +1,6 @@
 export default function NotFound() {
   return (
-    <div className="p-4">
+    <div className="p-4 max-w-screen-xl mx-auto">
       <h2>404 - Page Not Found</h2>
     </div>
   );


### PR DESCRIPTION
## Summary
- overhaul `Header` with language selector and clean layout
- make `Footer` responsive with navigation links
- enforce `max-w-screen-xl` containers across pages
- tweak `HeroSearchBar` container width

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_685dda98cb608325aecf438f894c14a9