### PR TITLE
Integrate new assets and font

### DIFF
--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -2,11 +2,12 @@ import { useContext, useState } from 'react';
 import { NavLink } from 'react-router-dom';
 import { LanguageContext } from '../contexts/LanguageContext';
 import useTranslation from '../hooks/useTranslation';
+import LanguageSelector from './LanguageSelector';
 
 const TraveliaLogo = '/assets/Travelia_Logo.png';
 
 export default function Header() {
-  const { language, setLanguage } = useContext(LanguageContext);
+  const { language } = useContext(LanguageContext);
   const t = useTranslation();
   const [menuOpen, setMenuOpen] = useState(false);
   const isRTL = language === 'he';
@@ -71,14 +72,7 @@ export default function Header() {
               {t(p.name)}
             </NavLink>
           ))}
-          <select
-            value={language}
-            onChange={(e) => setLanguage(e.target.value)}
-            className="ml-2 text-black rounded px-2 py-1"
-          >
-            <option value="en">EN</option>
-            <option value="he">HE</option>
-          </select>
+          <LanguageSelector className="ml-2" />
         </nav>
       </div>
     </header>

--- a/frontend/src/components/LanguageSelector.jsx
+++ b/frontend/src/components/LanguageSelector.jsx
@@ -1,0 +1,25 @@
+import { useContext } from 'react';
+import { LanguageContext } from '../contexts/LanguageContext';
+
+const flags = {
+  he: '/assets/icons/il.svg',
+  en: '/assets/icons/us.svg',
+};
+
+export default function LanguageSelector({ className = '' }) {
+  const { language, setLanguage } = useContext(LanguageContext);
+  return (
+    <div className={`flex items-center gap-1 ${className}`}>
+      {Object.entries(flags).map(([lang, icon]) => (
+        <button
+          key={lang}
+          onClick={() => setLanguage(lang)}
+          aria-label={lang}
+          className={`p-1 rounded hover:bg-gray-200 transition ${language === lang ? 'ring-2 ring-primary' : ''}`}
+        >
+          <img src={icon} alt={`${lang} flag`} className="w-5 h-5" />
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,3 +2,17 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@font-face {
+  font-family: 'Secular One';
+  src: url('/assets/fonts/SecularOne-Regular.ttf') format('truetype');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
+@layer base {
+  body {
+    @apply font-secular;
+  }
+}

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -3,6 +3,7 @@ import useTranslation from '../hooks/useTranslation';
 import HeroSearchBar from '../components/HeroSearchBar';
 // Logo image lives under /assets when provided
 const logo = '/assets/Travelia_Logo.png';
+const homeBg = '/assets/images/home-bg.jpg';
 import HotelIcon from '../components/HotelIcon';
 import { fetchFlights } from '../api/flights';
 import { fetchHotels } from '../api/hotels';
@@ -70,7 +71,10 @@ export default function Home() {
     <>
       <SEO title="Travelia" description="Search flights and hotels" />
       <div className="space-y-6 max-w-screen-xl mx-auto px-4">
-        <div className="flex justify-center mt-8">
+        <div
+          className="h-48 sm:h-72 w-full bg-center bg-cover rounded-lg flex items-center justify-center mt-8"
+          style={{ backgroundImage: `url(${homeBg})` }}
+        >
           <img
             src={logo}
             alt="Travelia Logo"

--- a/frontend/src/pages/Hotels.jsx
+++ b/frontend/src/pages/Hotels.jsx
@@ -10,6 +10,8 @@ import { formatPrice } from '../utils/formatPrice';
 import LoadingSpinner from '../components/LoadingSpinner';
 import { mapToCity } from '../utils/cityMap';
 
+const hotelBg = '/assets/images/hotel.jpg';
+
 export default function Hotels() {
   const t = useTranslation();
   const { addDeal } = useContext(DealsContext);
@@ -52,6 +54,10 @@ export default function Hotels() {
     <>
       <SEO title={t('hotels')} description="Search hotels" />
       <div className="space-y-4 overflow-hidden max-w-screen-xl mx-auto px-4">
+        <div
+          className="h-48 sm:h-72 w-full bg-center bg-cover rounded-lg"
+          style={{ backgroundImage: `url(${hotelBg})` }}
+        />
         <h2 className="text-xl font-bold">{t('hotels')}</h2>
 
         <HeroSearchBar type="hotel" showTripType={false} onSearch={search} />

--- a/frontend/src/pages/NotFound.jsx
+++ b/frontend/src/pages/NotFound.jsx
@@ -1,7 +1,10 @@
+const notFoundImg = '/assets/images/404-suitcase.jpg';
+
 export default function NotFound() {
   return (
-    <div className="p-4 max-w-screen-xl mx-auto">
-      <h2>404 - Page Not Found</h2>
+    <div className="p-4 max-w-screen-xl mx-auto text-center space-y-4">
+      <img src={notFoundImg} alt="404" className="mx-auto w-2/3 max-w-xs" />
+      <h2 className="text-2xl font-bold">404 - Page Not Found</h2>
     </div>
   );
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -4,7 +4,8 @@ module.exports = {
   theme: {
     extend: {
       fontFamily: {
-        sans: ['Inter', 'Poppins', 'Heebo', 'Rubik', 'sans-serif'],
+        sans: ['"Secular One"', 'Inter', 'Poppins', 'Heebo', 'Rubik', 'sans-serif'],
+        secular: ['"Secular One"', 'sans-serif'],
       },
       colors: {
         primary: {


### PR DESCRIPTION
## Summary
- add reusable `LanguageSelector` component with flag icons
- apply background images to **Home** and **Hotels** pages
- enhance 404 page with suitcase illustration
- load `Secular One` font locally and set as default
- update Tailwind configuration with new font family

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e49b2855883258a637a196604c0ed