### PR TITLE
Add assets references and Hebrew tagline

### DIFF
--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -4,8 +4,6 @@ import { LanguageContext } from '../contexts/LanguageContext';
 import useTranslation from '../hooks/useTranslation';
 import LanguageSelector from './LanguageSelector';
 
-const TraveliaLogo = '/assets/Travelia_Logo.png';
-
 export default function Header() {
   const { language } = useContext(LanguageContext);
   const t = useTranslation();
@@ -21,10 +19,6 @@ export default function Header() {
     { name: 'contact', path: '/contact' },
   ];
 
-  const slogans = {
-    he: 'טראווליה — הדרך הקלה והחכמה לטיסות ולחופשות',
-    en: 'Travelia — Your smart and easy flight & travel companion',
-  };
 
   return (
     <header className="bg-primary text-white shadow">
@@ -35,9 +29,9 @@ export default function Header() {
       >
         {/* Logo and slogan */}
         <div className="flex items-center gap-3">
-          <img src={TraveliaLogo} alt="Travelia logo" className="h-10 w-10" />
+          <img src="/assets/icons/logo.png" alt="Travelia Logo" className="h-10" />
           <p className="text-sm md:text-base font-bold whitespace-nowrap">
-            {slogans[language]}
+            טראווליה — הדרך הקלה והחכמה לטיסות ולחופשות
           </p>
         </div>
 

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -71,15 +71,19 @@ export default function Home() {
     <>
       <SEO title="Travelia" description="Search flights and hotels" />
       <div className="space-y-6 max-w-screen-xl mx-auto px-4">
-        <div
-          className="h-48 sm:h-72 w-full bg-center bg-cover rounded-lg flex items-center justify-center mt-8"
-          style={{ backgroundImage: `url(${homeBg})` }}
-        >
+        <div className="relative mt-8 h-48 sm:h-72 w-full rounded-lg overflow-hidden">
           <img
-            src={logo}
-            alt="Travelia Logo"
-            className="h-24 md:h-32 w-auto drop-shadow-lg"
+            src={homeBg}
+            alt="בריכה ודקלים"
+            className="absolute inset-0 w-full h-full object-cover"
           />
+          <div className="absolute inset-0 flex items-center justify-center">
+            <img
+              src={logo}
+              alt="Travelia Logo"
+              className="h-24 md:h-32 w-auto drop-shadow-lg"
+            />
+          </div>
         </div>
 
         <HeroSearchBar onSearch={handleSearch} />

--- a/frontend/src/pages/Hotels.jsx
+++ b/frontend/src/pages/Hotels.jsx
@@ -54,10 +54,13 @@ export default function Hotels() {
     <>
       <SEO title={t('hotels')} description="Search hotels" />
       <div className="space-y-4 overflow-hidden max-w-screen-xl mx-auto px-4">
-        <div
-          className="h-48 sm:h-72 w-full bg-center bg-cover rounded-lg"
-          style={{ backgroundImage: `url(${hotelBg})` }}
-        />
+        <div className="mt-4 relative h-48 sm:h-72 w-full rounded-lg overflow-hidden">
+          <img
+            src={hotelBg}
+            alt="מלון ובריכה"
+            className="absolute inset-0 w-full h-full object-cover"
+          />
+        </div>
         <h2 className="text-xl font-bold">{t('hotels')}</h2>
 
         <HeroSearchBar type="hotel" showTripType={false} onSearch={search} />


### PR DESCRIPTION
## Summary
- show Travelia logo and Hebrew slogan in `Header`
- display hero images with `<img>` in Home and Hotels pages

## Testing
- `npm test` (frontend)
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_685e5c0940548325b5ad73b9c29fd0cb